### PR TITLE
added dynamicAttributes to SessionEndEvent

### DIFF
--- a/sessionizer/src/main/java/com/ebay/pulsar/sessionizer/impl/Sessionizer.java
+++ b/sessionizer/src/main/java/com/ebay/pulsar/sessionizer/impl/Sessionizer.java
@@ -356,6 +356,11 @@ public class Sessionizer {
             sessionEndEvent.putAll(initialAttributes);
         }
 
+        Map<String, Object> dynamicAttributes = session.getDynamicAttributes();
+        if (dynamicAttributes != null) {
+            sessionEndEvent.putAll(dynamicAttributes);
+        }        
+        
         session.setSessionId(concatTimestamp(identifier, session.getFirstEventTimestamp()));
 
         if (mainSessionProfile.getSessionIdKey() != null) {


### PR DESCRIPTION
Hi, we've been trying to get the dynamic attributes inside the `SessionEndEvent` by adding a simple EPL expression with the `UpdateCounter` annotation.

```
@UpdateCounter("pageviews")
select * from
PulsarEvent;
```

To the PulsarEPL statementBlock in the sessionizer config `sessionizerconfig.xml` however we were able to see, after debugging, that although the counter was getting updated correctly it was not being added to the `SessionEndEvent` and so we couldn't access it later in the metrics calculator, or anywhere else for that matter. 

My first guess Is we are doing something wrong and missing something that is not in the docs, however this simple modification correctly adds the dynamic attributes to the `SessionEndEvent` and we are able to extract the field's value later when calculating metrics.

If this is not the right approach, I would appreciate you pointing us in the right direction. In case this is actually something useful that was missing, I'm submitting the PR for your review. 

I couldn't find any corresponding tests which is why I didn't add any for this simple code addition.

Thanks!

Oscar
